### PR TITLE
Enhance security: add helmet, fix redirects, improve error handling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Storage
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM node:21.1.0-bullseye
+FROM node:22-alpine
 
 WORKDIR /opt/caais-middleware/
 COPY ./package*.json ./
-RUN npm ci
+RUN npm ci --omit=dev
 
 COPY ./ ./
+
+# Run as non-root user for least-privilege execution.
+USER node
 
 CMD ["npm", "run", "start"]

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -28,7 +28,7 @@ const ConfigurationSchema = z.object({
      * A secret with minimum length of 32 characters.
      * We use this to sign the cookies.
      */
-    cookiesSecret: z.string(),
+    cookiesSecret: z.string().min(32),
   }),
   /**
    * CAAIS configuration.
@@ -41,11 +41,11 @@ const ConfigurationSchema = z.object({
     /**
      * CAAIS server URL.
      */
-    hostUrl: z.string(),
+    hostUrl: z.string().url(),
     /**
      * CAAIS callback redirect URL.
      */
-    callbackUrl: z.string(),
+    callbackUrl: z.string().url(),
     /**
      * Certificate.
      */
@@ -67,7 +67,7 @@ const ConfigurationSchema = z.object({
      * CAAIS login endpoint.
      * We redirect user to this endpoint for login
      */
-    loginEndpointUrl: z.string(),
+    loginEndpointUrl: z.string().url(),
     /**
      * CAAIS token source endpoint from which we get the security token.
      */

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 
 import express, { Express, Request, Response, NextFunction } from "express";
 import session from "express-session";
+import helmet from "helmet";
 import * as undici from "undici";
 import * as openid from "openid-client";
 
@@ -44,6 +45,10 @@ function createHttp(
   oidcClient: openid.Configuration,
 ): Express {
   const application = express();
+
+  // Apply security headers via helmet.
+  application.use(helmet());
+
   configureSession(configuration, application);
 
   application.get("/", (req, res) => {
@@ -51,44 +56,38 @@ function createHttp(
   });
 
   application.get("/login",
-    (req, res) => {
+    (req, res, next) => {
       console.log("/login");
-      try {
-        handleLogin(configuration, oidcClient, req, res)
-      } catch (error) {
-        console.log("  ", error);
-        res.send();
-      }
+      handleLogin(configuration, oidcClient, req, res).catch(error => {
+        console.error("  ", error);
+        res.status(500).send();
+      });
     });
   application.get("/callback",
-    (req, res) => {
+    (req, res, next) => {
       console.log("/callback");
-      try {
-        handleCaaisCallback(configuration, oidcClient, req, res)
-      } catch (error) {
-        console.log("  ", error);
-        res.send();
-      }
+      handleCaaisCallback(configuration, oidcClient, req, res).catch(error => {
+        console.error("  ", error);
+        res.status(500).send();
+      });
     });
   application.get("/logout",
-    (req, res) => {
+    (req, res, next) => {
       console.log("/logout");
       try {
         handleLogout(configuration, oidcClient, req, res)
       } catch (error) {
-        console.log("  ", error);
-        res.send();
+        console.error("  ", error);
+        res.status(500).send();
       }
     });
   application.get("/authenticate",
-    (req, res) => {
+    (req, res, next) => {
       console.log("/authenticate");
-      try {
-        handleAuthenticate(configuration, oidcClient, req, res)
-      } catch (error) {
-        console.log("  ", error);
-        res.send();
-      }
+      handleAuthenticate(configuration, oidcClient, req, res).catch(error => {
+        console.error("  ", error);
+        res.status(500).send();
+      });
     });
 
   // TODO : Handle 404 codes.
@@ -106,11 +105,16 @@ function configureSession(configuration: Configuration, application: Express) {
     name: configuration.http.cookieName,
     secret: configuration.http.cookiesSecret,
     resave: false,
-    saveUninitialized: true,
+    // Only save session when it has been modified (not on every request).
+    // This prevents session store flooding and avoids creating tracking
+    // cookies for unauthenticated requests.
+    saveUninitialized: false,
     cookie: {
       maxAge: 60 * 60 * 1000, // One hour.
       httpOnly: true,
       secure: false,
+      // Restrict cross-site cookie sending to mitigate CSRF.
+      sameSite: "lax",
     },
   }));
 
@@ -149,6 +153,21 @@ declare module "express-session" {
   }
 }
 
+/**
+ * Validates that a redirect URL is safe (relative path or same-origin).
+ * Returns the sanitized URL, or an empty string if the URL is unsafe.
+ */
+function sanitizeRedirectUrl(raw: string | undefined): string {
+  if (!raw || raw === "undefined") {
+    return "";
+  }
+  // Allow only relative paths starting with /
+  if (/^\/[^/\\]/.test(raw) || raw === "/") {
+    return raw;
+  }
+  return "";
+}
+
 async function handleLogin(
   configuration: Configuration,
   oidcClient: openid.Configuration,
@@ -170,9 +189,11 @@ async function handleLogin(
   const nonce = openid.randomNonce();
   session.caais.nonce = nonce;
 
-  // Store redirect url.
-  // TODO We need a reasonable callback URL as a default.
-  session.caais.redirectUrl = String(request.query["redirect-url"]) ?? "";
+  // Store redirect url - only allow safe relative paths to prevent open redirect.
+  const rawRedirect = request.query["redirect-url"];
+  session.caais.redirectUrl = sanitizeRedirectUrl(
+    Array.isArray(rawRedirect) ? String(rawRedirect[0]) : String(rawRedirect)
+  );
 
   // Build authorization URL
   const authUrl = openid.buildAuthorizationUrl(oidcClient, {
@@ -217,14 +238,16 @@ async function handleCaaisCallback(
   const userInfo = await openid.fetchUserInfo(
     oidcClient,
     tokens.access_token,
-    //tokens.sub  // Add the subject from the token
-    openid.skipSubjectCheck // decodedPayload.sub
+    tokens.claims()?.sub,  // Verify subject claim matches the token
   );
 
   // Update state.
   session.caais.authenticated = true;
   session.caais.idToken = tokens.id_token;
   session.caais.refreshToken = tokens.refresh_token;
+  session.caais.expiresAt = tokens.expires_in
+    ? Math.floor(Date.now() / 1000) + tokens.expires_in
+    : undefined;
 
   session.headers["x-caais-token"] = JSON.stringify({
     authenticated: true,
@@ -241,8 +264,9 @@ async function handleCaaisCallback(
     }
   });
 
-  // Redirect back to the original page.
-  response.redirect(session.caais.redirectUrl!);
+  // Redirect back to the original page (already sanitized at login time).
+  const redirectUrl = session.caais.redirectUrl || "/";
+  response.redirect(redirectUrl);
 }
 
 function handleLogout(
@@ -275,7 +299,9 @@ function handleLogout(
   logoutUrl.searchParams.set("post_logout_redirect_uri",
     configuration.caais.callbackUrl);
   logoutUrl.searchParams.set("client_id", configuration.caais.clientId);
-  logoutUrl.searchParams.set("state", caais.state!);
+  // Generate a fresh state for the logout request rather than reusing the
+  // login state which may have already been consumed or invalidated.
+  logoutUrl.searchParams.set("state", openid.randomState());
   return response.redirect(logoutUrl.href);
 }
 
@@ -300,12 +326,26 @@ async function handleAuthenticate(
       authenticated: false,
     }));
     response.send();
+    return;
   }
 
   const now = Math.floor(Date.now() / 1000);
   if (caais.expiresAt && caais.expiresAt < now + 300) {
-    const newTokens = await refreshAccessToken(oidcClient, caais.refreshToken!);
-    // TODO Store new tokens ...
+    try {
+      const newTokens = await refreshAccessToken(oidcClient, caais.refreshToken!);
+      // Store refreshed tokens in the session.
+      caais.refreshToken = newTokens.refresh_token ?? caais.refreshToken;
+      caais.idToken = newTokens.id_token ?? caais.idToken;
+      caais.expiresAt = newTokens.expires_in
+        ? Math.floor(Date.now() / 1000) + newTokens.expires_in
+        : caais.expiresAt;
+    } catch (error) {
+      // Token refresh failed; clear session and report unauthenticated.
+      clearSessionData(request.session as any);
+      response.header("x-caais-token", JSON.stringify({ authenticated: false }));
+      response.send();
+      return;
+    }
   }
 
   // Send headers to the client.


### PR DESCRIPTION
## Summary
This PR significantly improves the security posture of the CAAIS middleware by adding HTTP security headers, implementing open redirect protection, improving error handling, and enhancing session configuration.

## Key Changes

### Security Enhancements
- **Add Helmet.js**: Integrated helmet middleware to automatically set secure HTTP headers (CSP, X-Frame-Options, etc.)
- **Open Redirect Protection**: Implemented `sanitizeRedirectUrl()` function to validate redirect URLs, allowing only safe relative paths (starting with `/`) to prevent open redirect vulnerabilities
- **Session Security**: 
  - Changed `saveUninitialized` from `true` to `false` to prevent unnecessary session creation and tracking cookies
  - Added `sameSite: "lax"` cookie attribute to mitigate CSRF attacks
- **Configuration Validation**: Enhanced Zod schema validation to enforce URL format and minimum secret length (32 characters)

### Error Handling Improvements
- Converted try-catch blocks in route handlers to promise-based `.catch()` patterns for async operations
- Added proper HTTP status codes (500) to error responses instead of empty responses
- Improved error logging with `console.error()` instead of `console.log()`
- Added early returns in error paths to prevent further execution

### Token Management
- **Subject Claim Verification**: Updated `handleCaaisCallback()` to pass the subject claim from tokens to `fetchUserInfo()` for proper verification
- **Token Expiration Tracking**: Added `expiresAt` field to session to track token expiration times
- **Token Refresh**: Implemented proper token refresh logic in `handleAuthenticate()` with error handling and session clearing on refresh failure
- **Logout State**: Changed logout to use a fresh random state instead of reusing the login state

### Infrastructure Updates
- Updated Docker base image from `node:21.1.0-bullseye` to `node:22-alpine` for smaller image size and latest LTS
- Added non-root user execution (`USER node`) for least-privilege container security
- Added `--omit=dev` flag to npm ci to exclude development dependencies from production image

## Notable Implementation Details
- Redirect URL sanitization happens at login time and is reused at callback time, with a fallback to "/" if missing
- Token refresh failures gracefully degrade by clearing the session and reporting unauthenticated status
- All async handlers now properly handle promise rejections instead of relying on try-catch

https://claude.ai/code/session_01HwrBFruNVSzz8E8jqh3pXX